### PR TITLE
fix: Add retry mechanism and error handling for message retrieval

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,9 +48,18 @@ def send_message(message):
 
 def get_last_message():
     """Get the latest message"""
-    page_elements = PAGE.query_selector_all(".flex.flex-col.items-center > div")
-    last_element = page_elements[-2]
-    return last_element.inner_text()
+    # Wait for messages to appear (up to 10 seconds)
+    max_retries = 20
+    retry_count = 0
+    while retry_count < max_retries:
+        page_elements = PAGE.query_selector_all(".flex.flex-col.items-center > div")
+        if len(page_elements) >= 2:
+            return page_elements[-2].inner_text()
+        time.sleep(0.5)
+        retry_count += 1
+    
+    # If we couldn't find any messages after waiting
+    raise Exception("No messages found after waiting for response")
 
 @APP.route("/chat", methods=["GET"])
 def chat():


### PR DESCRIPTION
This PR addresses the issue #90 where users were receiving 500 Internal Server Error when sending messages. The error occurred due to an IndexError when trying to access messages before they were fully loaded.

Changes made:
- Added a retry mechanism that waits up to 10 seconds for messages to appear
- Implemented proper error handling for cases where no messages are found
- Added length validation before accessing message elements
- Improved error messaging for better debugging

The fix ensures that the server waits for messages to be properly loaded before attempting to retrieve them, preventing the IndexError that was causing the 500 Internal Server Error.

Testing:
- Verified that messages are now properly retrieved after the waiting period
- Confirmed that appropriate error messages are shown if no messages are found after the timeout
- Tested with various message lengths and response times

Closes #90